### PR TITLE
Switch out Buffer with btoa for building base64 Authorization header

### DIFF
--- a/src/jiraClient.ts
+++ b/src/jiraClient.ts
@@ -20,7 +20,7 @@ export class JiraClient {
     private buildHeaders(): Record<string, string> {
         const requestHeaders: Record<string, string> = {}
         if (this._settings.authenticationType === EAuthenticationTypes.BASIC) {
-            requestHeaders['Authorization'] = 'Basic ' + Buffer.from(`${this._settings.username}:${this._settings.password}`).toString('base64')
+            requestHeaders['Authorization'] = 'Basic ' + btoa(`${this._settings.username}:${this._settings.password}`)
         } else if (this._settings.authenticationType === EAuthenticationTypes.BEARER_TOKEN) {
             requestHeaders['Authorization'] = `Bearer ${this._settings.bareToken}`
         }


### PR DESCRIPTION
Closes #9

This PR switches out the usage of `Buffer`, a Node.js standard library module [with the more widely available `btoa` which is available in every browser](https://developer.mozilla.org/en-US/docs/Web/API/btoa#browser_compatibility).

I originally went down the path of trying to use [a buffer polyfill](https://github.com/feross/buffer) but try as I might, I couldn't actually get the module's code to be bundled into `main.js` as it does with `moment` for example.

I will note that Node.js has marked `btoa` as deprecated in favour of `Buffer`:

![CleanShot 2022-05-03 at 22 39 27](https://user-images.githubusercontent.com/14816406/166440401-5bf0736a-3f4f-448c-8975-2ebe95ba2ade.png)

The key bits here are probably 
> provided for compatibility with legacy web platform APIs

and

> For code running using Node.js APIs

As scary as the message sounds, it does imply that `btoa` is fine to use if your use case is not strictly bound to Node.js which this plugin isn't really.

Anyway, it works for now regardless. It's probably worth investigating if there's something better down the line.

The next thing after this will be looking at the mobile table formatting since they're quite wide 😅 

**Before**: Issues fail to load on iOS
![IMG_2302](https://user-images.githubusercontent.com/14816406/166440052-b6391c05-d7bd-4e08-8ae3-407c7e97ae05.jpg)

**After**: Issues load on iOS
![IMG_2303](https://user-images.githubusercontent.com/14816406/166440059-3bcf7927-ba87-4d52-9cd7-520c9cffa7e6.PNG)

