### PR TITLE
Close donation anchor tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This plugin allows you to track the progress of [Atlassian Jira](https://www.atl
 
 <!-- /TOC -->
 
-<a href='https://ko-fi.com/marc0l92' target='_blank'><img height='35' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png' border='0' alt='Buy Me a Coffee' />
+<a href='https://ko-fi.com/marc0l92' target='_blank'><img height='35' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png' border='0' alt='Buy Me a Coffee' /></a>
 
 
 ![issues](./doc/issues.png)


### PR DESCRIPTION
I noticed that the rendered description in the Obsidian community plugin list is rendered as one giant link. This is due to a missing `</a>` tag in the Ko-Fi link at the top of the README

![CleanShot 2022-06-14 at 11 41 34](https://user-images.githubusercontent.com/14816406/173464904-8180af27-ae7d-4ae9-8318-4371222952a2.png)
