### PR TITLE
fix: link to standard-fields header

### DIFF
--- a/docs-gen/docs/components/jira-search.md
+++ b/docs-gen/docs/components/jira-search.md
@@ -27,7 +27,7 @@ It is possible to describe in each jira-search fence how the search results are 
 | `type` | Rendering mode of the search results | `TABLE` | `TABLE` or `LIST` |
 | `query` | Query to use with Jira to retrieve the results |  |  |
 | `limit` | Maximum number of items to display | Use value from settings | Integer number |
-| `columns` | List of columns to render ([Available columns](#standard-columns)) | Use value from settings | Comma separated list |
+| `columns` | List of columns to render ([Available columns](#standard-fields)) | Use value from settings | Comma separated list |
 | `account` | Explicitly select an account providing the alias | Try all account by priority | Account alias |
 
 Example:


### PR DESCRIPTION
The `Available columns` link in the "Advanced Usage" table is dead, fixing to point to `Standard Fields` header.