### PR TITLE
feat: allow to jump directly Jira search website from  jira-search 

### DIFF
--- a/src/interfaces/settingsInterfaces.ts
+++ b/src/interfaces/settingsInterfaces.ts
@@ -37,7 +37,8 @@ export interface IJiraIssueSettings {
     logRequestsResponses: boolean
     logImagesFetch: boolean
     showColorBand: boolean
-
+    showJiraLink: boolean
+    
     // Legacy credentials
     host?: string
     authenticationType?: EAuthenticationTypes

--- a/src/rendering/renderingCommon.ts
+++ b/src/rendering/renderingCommon.ts
@@ -22,10 +22,10 @@ export default {
 
     searchUrl(account: IJiraIssueAccountSettings, searchQuery: string): string {
         try {
-            return (new URL(`${account.host}/issues?filter=-4&jql=${searchQuery}`)).toString()
+            return (new URL(`${account.host}/issues/?jql=${searchQuery}`)).toString()
         } catch (e) { return '' }
     },
-
+    
     getTheme(): string {
         switch (SettingsData.colorSchema) {
             case EColorSchema.FOLLOW_OBSIDIAN:

--- a/src/rendering/searchFenceRenderer.ts
+++ b/src/rendering/searchFenceRenderer.ts
@@ -82,10 +82,21 @@ function getAccountBandStyle(account: IJiraIssueAccountSettings): string {
 
 function renderSearchFooter(rootEl: HTMLElement, searchView: SearchView, searchResults: IJiraSearchResults): HTMLElement {
     const searchFooter = createDiv({ cls: 'search-footer' })
-    createDiv({
-        text: `Total results: ${searchResults.total.toString()} - ${searchResults.account.alias}`,
-        parent: searchFooter,
-    })
+    const searchCount = `Total results: ${searchResults.total.toString()} - ${searchResults.account.alias}`
+
+    if(SettingsData.showJiraLink) {
+        createEl('a', {
+            text: searchCount,
+            href: RC.searchUrl(searchView.account, searchView.query),
+            parent: searchFooter,
+        })
+    } else {
+        createDiv({
+            text: searchCount,
+            parent: searchFooter,
+        })
+    }
+
     const lastUpdateContainer = createDiv({ parent: searchFooter })
     createSpan({
         text: `Last update: ${ObjectsCache.getTime(searchView.getCacheKey())}`,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,6 +23,7 @@ export const DEFAULT_SETTINGS: IJiraIssueSettings = {
     inlineIssueUrlToTag: true,
     inlineIssuePrefix: 'JIRA:',
     showColorBand: true,
+    showJiraLink: true,
     searchColumns: [
         { type: ESearchColumnsTypes.KEY, compact: false },
         { type: ESearchColumnsTypes.SUMMARY, compact: false },
@@ -473,6 +474,16 @@ export class JiraIssueSettingTab extends PluginSettingTab {
                 .onChange(async value => {
                     SettingsData.showColorBand = value
                     await this.saveSettings()
+                }))
+        
+        new Setting(containerEl)
+            .setName('Show Jira link')
+            .setDesc('Make the result count in jira-search a link to the jira project with the jql from the search.')
+            .addToggle(toggle => toggle
+                .setValue(SettingsData.showJiraLink)
+                .onChange(async value => {
+                    SettingsData.showJiraLink = value
+                    await this.saveSettings()                    
                 }))
     }
 

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -34,6 +34,7 @@ const StoredSettings = {
     ],
     searchResultsLimit: 99,
     showColorBand: true,
+    showJiraLink: true,
 } as IJiraIssueSettings
 
 describe('Settings', () => {


### PR DESCRIPTION
## Change
- Adds functionality to allow jumping from jira-search directly onto the Jira search website with the query in jira-search.
- This function can be enabled in the settings


https://github.com/marc0l92/obsidian-jira-issue/issues/97