### PR TITLE
feat: add account setting for disabling icon fetching

### DIFF
--- a/src/client/jiraClient.ts
+++ b/src/client/jiraClient.ts
@@ -2,6 +2,7 @@ import { Platform, requestUrl, RequestUrlParam, RequestUrlResponse } from 'obsid
 import { AVATAR_RESOLUTION, EAuthenticationTypes, IJiraIssueAccountSettings } from '../interfaces/settingsInterfaces'
 import { ESprintState, IJiraAutocompleteField, IJiraBoard, IJiraDevStatus, IJiraField, IJiraIssue, IJiraSearchResults, IJiraSprint, IJiraStatus, IJiraUser } from '../interfaces/issueInterfaces'
 import { SettingsData } from "../settings"
+import { JIRA_ISSUE_TYPE_ICON_MAP, JIRA_DEFAULT_ISSUE_ICON, JIRA_DEFAULT_PRIORITY_ICON, JIRA_PRIORITY_ICON_MAP} from 'src/rendering/renderingCommon'
 
 interface RequestOptions {
     method: string
@@ -157,18 +158,35 @@ async function preFetchImage(account: IJiraIssueAccountSettings, url: string): P
 }
 
 async function fetchIssueImages(issue: IJiraIssue) {
+    const disableImages = issue.account.disableImageFetch;
     if (issue.fields) {
         if (issue.fields.issuetype && issue.fields.issuetype.iconUrl) {
-            issue.fields.issuetype.iconUrl = await preFetchImage(issue.account, issue.fields.issuetype.iconUrl)
+            if (disableImages) {
+                issue.fields.issuetype.iconUrl = JIRA_ISSUE_TYPE_ICON_MAP[issue.fields.issuetype.name.toLowerCase()] || JIRA_DEFAULT_ISSUE_ICON
+            } else {
+                issue.fields.issuetype.iconUrl = await preFetchImage(issue.account, issue.fields.issuetype.iconUrl)
+            }
         }
         if (issue.fields.reporter) {
-            issue.fields.reporter.avatarUrls[AVATAR_RESOLUTION] = await preFetchImage(issue.account, issue.fields.reporter.avatarUrls[AVATAR_RESOLUTION])
+            if (disableImages) {
+                issue.fields.reporter.avatarUrls[AVATAR_RESOLUTION] = ""
+            } else {
+                issue.fields.reporter.avatarUrls[AVATAR_RESOLUTION] = await preFetchImage(issue.account, issue.fields.reporter.avatarUrls[AVATAR_RESOLUTION])
+            }
         }
         if (issue.fields.assignee && issue.fields.assignee.avatarUrls && issue.fields.assignee.avatarUrls[AVATAR_RESOLUTION]) {
-            issue.fields.assignee.avatarUrls[AVATAR_RESOLUTION] = await preFetchImage(issue.account, issue.fields.assignee.avatarUrls[AVATAR_RESOLUTION])
+            if (disableImages) {
+                issue.fields.assignee.avatarUrls[AVATAR_RESOLUTION] = ""
+            } else {
+                issue.fields.assignee.avatarUrls[AVATAR_RESOLUTION] = await preFetchImage(issue.account, issue.fields.assignee.avatarUrls[AVATAR_RESOLUTION])
+            }
         }
         if (issue.fields.priority && issue.fields.priority.iconUrl) {
-            issue.fields.priority.iconUrl = await preFetchImage(issue.account, issue.fields.priority.iconUrl)
+            if (disableImages) {
+                issue.fields.priority.iconUrl = JIRA_PRIORITY_ICON_MAP[issue.fields.priority.name.toLowerCase()] || JIRA_DEFAULT_PRIORITY_ICON
+            } else {
+                issue.fields.priority.iconUrl = await preFetchImage(issue.account, issue.fields.priority.iconUrl)
+            }
         }
     }
 }

--- a/src/client/jiraClient.ts
+++ b/src/client/jiraClient.ts
@@ -162,7 +162,7 @@ async function fetchIssueImages(issue: IJiraIssue) {
     if (issue.fields) {
         if (issue.fields.issuetype && issue.fields.issuetype.iconUrl) {
             if (disableImages) {
-                issue.fields.issuetype.iconUrl = JIRA_ISSUE_TYPE_ICON_MAP[issue.fields.issuetype.name.toLowerCase()] || JIRA_DEFAULT_ISSUE_ICON
+                issue.fields.issuetype.iconUrl = JIRA_ISSUE_TYPE_ICON_MAP[issue.fields.issuetype.name.toLowerCase()] || (issue.fields.issuetype.name.toLowerCase().startsWith("sub-") && JIRA_ISSUE_TYPE_ICON_MAP["subtask"]) || JIRA_DEFAULT_ISSUE_ICON
             } else {
                 issue.fields.issuetype.iconUrl = await preFetchImage(issue.account, issue.fields.issuetype.iconUrl)
             }

--- a/src/interfaces/settingsInterfaces.ts
+++ b/src/interfaces/settingsInterfaces.ts
@@ -56,6 +56,7 @@ export interface IJiraIssueAccountSettings {
     bareToken?: string
     priority: number
     color: string
+    disableImageFetch: boolean
     cache: {
         statusColor: Record<string, string>
         customFieldsIdToName: Record<string, string>

--- a/src/rendering/renderingCommon.ts
+++ b/src/rendering/renderingCommon.ts
@@ -5,6 +5,47 @@ import { ObsidianApp } from "../main"
 import { SearchView } from "../searchView"
 import { SettingsData } from "../settings"
 
+const JIRA_ICON_BASE_URL = 'https://bitbucket.org/atlassian/atlassian-frontend-mirror/raw/d01ccea001254920f3c2f0e0473aa09802acaaba/design-system/'
+export const JIRA_ISSUE_ICON_SVG_BASE_URL = JIRA_ICON_BASE_URL + 'icon-object/svgs_raw/'
+export const JIRA_PRIORITY_ICON_SVG_BASE_URL = JIRA_ICON_BASE_URL + 'icon/icons_raw/core/'
+
+function generateJiraIssueTypeSvgURL(issue_type: string): string {
+    return JIRA_ISSUE_ICON_SVG_BASE_URL + issue_type + "/16.svg"
+}
+
+function generateJiraIssuePrioritySvgURL(priority: string): string {
+    return JIRA_PRIORITY_ICON_SVG_BASE_URL + "priority-" + priority + ".svg"
+}
+
+export const JIRA_ISSUE_TYPE_ICON_MAP: Record<string, string> = {
+    'bug': generateJiraIssueTypeSvgURL('bug'),
+    'epic': generateJiraIssueTypeSvgURL('epic'),
+    'improvement': generateJiraIssueTypeSvgURL('improvement'),
+    'incident': generateJiraIssueTypeSvgURL('incident'),
+    'issue': generateJiraIssueTypeSvgURL('issue'),
+    'problem': generateJiraIssueTypeSvgURL('problem'),
+    'question': generateJiraIssueTypeSvgURL('question'),
+    'story': generateJiraIssueTypeSvgURL('story'),
+    'subtask': generateJiraIssueTypeSvgURL('subtask'),
+    'task': generateJiraIssueTypeSvgURL('task'),
+}
+
+export const JIRA_PRIORITY_ICON_MAP: Record<string, string> = {
+    'blocker': generateJiraIssuePrioritySvgURL('blocker'),
+    'critical': generateJiraIssuePrioritySvgURL('critical'),
+    'high': generateJiraIssuePrioritySvgURL('high'),
+    'highest': generateJiraIssuePrioritySvgURL('highest'),
+    'low': generateJiraIssuePrioritySvgURL('low'),
+    'lowest': generateJiraIssuePrioritySvgURL('lowest'),
+    'major': generateJiraIssuePrioritySvgURL('major'),
+    'medium': generateJiraIssuePrioritySvgURL('medium'),
+    'minor': generateJiraIssuePrioritySvgURL('minor'),
+    'trivial': generateJiraIssuePrioritySvgURL('trivial'),
+}
+
+export const JIRA_DEFAULT_ISSUE_ICON = JIRA_ISSUE_TYPE_ICON_MAP["issue"]
+export const JIRA_DEFAULT_PRIORITY_ICON = JIRA_PRIORITY_ICON_SVG_BASE_URL + "question-circle.svg"
+
 export const JIRA_STATUS_COLOR_MAP: Record<string, string> = {
     'blue-gray': 'is-info',
     'yellow': 'is-warning',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -46,6 +46,7 @@ export const DEFAULT_ACCOUNT: IJiraIssueAccountSettings = {
     password: '',
     priority: 1,
     color: '#000000',
+    disableImageFetch: false,
     cache: {
         statusColor: {},
         customFieldsIdToName: {},
@@ -92,6 +93,7 @@ export class JiraIssueSettingTab extends PluginSettingTab {
                         username: SettingsData.username,
                         password: SettingsData.password,
                         bareToken: SettingsData.bareToken,
+                        disableImageFetch: DEFAULT_ACCOUNT.disableImageFetch,
                         alias: DEFAULT_ACCOUNT.alias,
                         color: DEFAULT_ACCOUNT.color,
                         cache: DEFAULT_ACCOUNT.cache,
@@ -261,6 +263,15 @@ export class JiraIssueSettingTab extends PluginSettingTab {
                     // Force refresh
                     this.displayModifyAccountPage(prevAccount, newAccount)
                 }))
+        new Setting(containerEl)
+                .setName('Disable Icon fetching')
+                .setDesc('Disable fetching of icons (e.g. issue type, priority) from this Jira server and instead use official icons from Atlassian.')
+                .addToggle(toggle => toggle
+                    .setValue(newAccount.disableImageFetch)
+                    .onChange(async value => {
+                        newAccount.disableImageFetch = value
+                        this.displayModifyAccountPage(prevAccount, newAccount)
+                    }))
         if (newAccount.authenticationType === EAuthenticationTypes.BASIC) {
             new Setting(containerEl)
                 .setName('Username')


### PR DESCRIPTION
related to #32 and #49

This adds a per-account setting to disable fetching of icons from the specified Jira server and instead use icons provided upstream by Atlassian.

It is useful in cases where you cannot fetch icons (e.g. due to permission issues), but would still like icons displayed instead of the current placeholder broken image icon.

## Before
![image](https://github.com/user-attachments/assets/24634e15-5048-42f4-8efc-b39dc364648d)
![image](https://github.com/user-attachments/assets/07ce6bf3-2d87-4c0d-ae13-c684b57710cc)

## After
![image](https://github.com/user-attachments/assets/9cfec2be-1f2e-4457-8b1b-49c8d34a4bae)
![image](https://github.com/user-attachments/assets/1c3c5279-3bfd-4c30-aadd-60f8f317fbbd)
