### PR TITLE
Configuration clarity

### DIFF
--- a/docs-gen/docs/get-started/basic-authentication.md
+++ b/docs-gen/docs/get-started/basic-authentication.md
@@ -24,7 +24,7 @@ The authentication type depends on the type of Jira you use:
 If you choose `Basic Authentication`, you need to provide the username and password to authenticate with the server.
 
 - **Jira Server**: Use your regular username and password.
-- **Jira Cloud**: Use your **email address** as the username, and an **API token** as the password. Note: Jira Cloud does **not** accept your regular password for API access.
+- **Jira Cloud**: Use your **email address** as the username, and an **API token** as the password. Note: Jira Cloud does **not** accept your regular password for API access. If you use your regular password instead of an API token, the connection may appear to work, but it will not return data as expected.
 
 To create a new API token in Jira Cloud, navigate to `Account Settings > Security > Create and manage API tokens`. You can find more details here: [Official Documentation](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/).
 

--- a/docs-gen/docs/get-started/basic-authentication.md
+++ b/docs-gen/docs/get-started/basic-authentication.md
@@ -6,10 +6,9 @@ sidebar_position: 3
 Access the plugin options using and in the `Connection` section configure the `host` and `authentication`.
 
 ## Host
-In case of Atlassian Jira Server or Jira Cloud the host is the base URL of your jira instance.
+In case of Atlassian Jira Server or Jira Cloud, the host is the base URL of your Jira instance.
 
 [Read more...](/docs/configuration/authentication#host)
-
 
 ## Authentication Types
 
@@ -22,12 +21,11 @@ The authentication type depends on the type of Jira you use:
 
 ### Username and password
 
-If you chose the `Basic Authentication` you need to provide the username and password to authenticate with the server.
+If you choose `Basic Authentication`, you need to provide the username and password to authenticate with the server.
 
-In case of Jira Server, the username and password are the same as you use to login.
+- **Jira Server**: Use your regular username and password.
+- **Jira Cloud**: Use your **email address** as the username, and an **API token** as the password. Note: Jira Cloud does **not** accept your regular password for API access.
 
-On the other hand, if you use Jira Cloud the username is your email and the password needs to be filled with an APIKey.
-
-You can create a new API token in Jira Cloud from `Account Settings > Security > Create and manage API tokens` ([Official Documentation](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)).
+To create a new API token in Jira Cloud, navigate to `Account Settings > Security > Create and manage API tokens`. You can find more details here: [Official Documentation](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/).
 
 [Read more...](/docs/configuration/authentication#username-and-password)


### PR DESCRIPTION
I updated the `basic-authentication.md` file to improve clarity after i messed around a bit while testing configuration host and authentication settings.

Improvements:

* Enhanced the instructions for setting up basic authentication by providing distinct guidelines for Jira Server and Jira Cloud, including the use of an API token for Jira Cloud. (`docs-gen/docs/get-started/basic-authentication.md`)