### PR TITLE
template and target folder support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ data.json
 
 # Reports
 coverage
+*.lock

--- a/src/interfaces/settingsInterfaces.ts
+++ b/src/interfaces/settingsInterfaces.ts
@@ -45,6 +45,9 @@ export interface IJiraIssueSettings {
     username?: string
     password?: string
     bareToken?: string
+
+    noteFolder?: string
+    noteTemplate?: string
 }
 
 export interface IJiraIssueAccountSettings {

--- a/src/rendering/renderingCommon.ts
+++ b/src/rendering/renderingCommon.ts
@@ -1,4 +1,4 @@
-import { FrontMatterCache, TFile } from "obsidian"
+import { FrontMatterCache, TFile, TFolder } from "obsidian"
 import { IJiraIssue } from "../interfaces/issueInterfaces"
 import { EColorSchema, IJiraIssueAccountSettings } from "../interfaces/settingsInterfaces"
 import { ObsidianApp } from "../main"
@@ -66,9 +66,25 @@ export default {
     getNotes(): TFile[] {
         return ObsidianApp.vault.getMarkdownFiles()
     },
-
+    
     getFrontMatter(file: TFile): FrontMatterCache {
         return ObsidianApp.metadataCache.getFileCache(file).frontmatter
+    },
+    
+    readNote(file: any): Promise<string> {
+        return ObsidianApp.vault.read(file)
+    },
+
+    createNote(path: string, contents: string): Promise<TFile> {
+        return ObsidianApp.vault.create(path, contents)
+    },
+
+    createFolder(path: string): Promise<TFolder> {
+        return ObsidianApp.vault.createFolder(path);
+    },
+
+    getAbstractFileByPath(path: string){
+        return ObsidianApp.vault.getAbstractFileByPath(path);
     },
 
     renderContainer(children: HTMLElement[]): HTMLElement {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -142,6 +142,7 @@ export class JiraIssueSettingTab extends PluginSettingTab {
         this.displayHeader()
         this.displayAccountsSettings()
         this.displayRenderingSettings()
+        this.displayNoteTemplateSettings();
         this.displaySearchColumnsSettings(isSearchColumnsDetailsOpen)
         this.displayExtraSettings()
         this.displayFooter()
@@ -418,6 +419,37 @@ export class JiraIssueSettingTab extends PluginSettingTab {
                     this.display()
                 }))
     }
+
+    displayNoteTemplateSettings() {
+        const { containerEl } = this;
+        containerEl.createEl("h3", { text: "Note template" });
+    
+        //template picker
+        new Setting(containerEl)
+            .setName('Note Template')
+            .setDesc("Template to use when creating a new note from a Jira issue.")
+            .addText(text => 
+                text
+                .setValue(SettingsData.noteTemplate)
+                .onChange(async (value) => {
+                    SettingsData.noteTemplate = value;
+                    await this.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Note Folder')
+            .setDesc("Folder where to save the new note.")
+            .addText(text => 
+                text
+                .setValue(SettingsData.noteFolder)
+                .onChange(async (value) => {
+                  SettingsData.noteFolder = value;
+                  await this.saveSettings();
+                })
+            );
+    
+      }
 
     displayRenderingSettings() {
         const { containerEl } = this


### PR DESCRIPTION
This fork adds 2 new settings: 
- Folder: Add a folder path in settings, upon pressing the +Note button, the note will be created in that specific folder
- Templates: If a template is provided, it will create a note with that template

![image](https://github.com/user-attachments/assets/cca83160-be30-41d7-9d0f-249680c073d5)
