### PR TITLE
Update to use Jira Cloud V3 API format

### DIFF
--- a/src/api/apiChart.ts
+++ b/src/api/apiChart.ts
@@ -46,7 +46,7 @@ export async function getWorklogPerDay(projectKeyOrId: string, startDate: string
     }
     const usersSeries: IMultiSeries = {}
     for (const worklog of worklogs) {
-        const author = worklog.author.accountId || worklog.author.displayName || worklog.author.name || 'Unknown'
+        const author = worklog.author?.accountId || worklog.author?.displayName || worklog.author?.name || 'Unknown'
         if (!usersSeries[author]) {
             usersSeries[author] = Object.assign({}, emptySeries)
         }

--- a/src/api/apiChart.ts
+++ b/src/api/apiChart.ts
@@ -46,7 +46,7 @@ export async function getWorklogPerDay(projectKeyOrId: string, startDate: string
     }
     const usersSeries: IMultiSeries = {}
     for (const worklog of worklogs) {
-        const author = worklog.author.name
+        const author = worklog.author.accountId || worklog.author.displayName || worklog.author.name || 'Unknown'
         if (!usersSeries[author]) {
             usersSeries[author] = Object.assign({}, emptySeries)
         }

--- a/src/api/apiMacro.ts
+++ b/src/api/apiMacro.ts
@@ -54,7 +54,7 @@ export async function getWorkLogSeriesByUser(projectKeyOrId: string, startDate: 
     const worklogs = await API.macro.getWorkLogByDates(projectKeyOrId, startDate, endDate)
     const series: ISeries = {}
     for (const worklog of worklogs) {
-        const author = worklog.author.accountId || worklog.author.displayName || worklog.author.name || 'Unknown'
+        const author = worklog.author?.accountId || worklog.author?.displayName || worklog.author?.name || 'Unknown'
         if (!(author in series)) {
             series[author] = 0
         }

--- a/src/api/apiMacro.ts
+++ b/src/api/apiMacro.ts
@@ -54,7 +54,7 @@ export async function getWorkLogSeriesByUser(projectKeyOrId: string, startDate: 
     const worklogs = await API.macro.getWorkLogByDates(projectKeyOrId, startDate, endDate)
     const series: ISeries = {}
     for (const worklog of worklogs) {
-        const author = worklog.author.name
+        const author = worklog.author.accountId || worklog.author.displayName || worklog.author.name || 'Unknown'
         if (!(author in series)) {
             series[author] = 0
         }

--- a/src/interfaces/issueInterfaces.ts
+++ b/src/interfaces/issueInterfaces.ts
@@ -94,9 +94,10 @@ export interface IJiraWorklog {
 export interface IJiraUser {
     active: boolean
     displayName: string
-    name: string
-    key: string
-    emailAddress: string
+    accountId: string
+    name?: string
+    key?: string
+    emailAddress?: string
     self: string
     avatarUrls: {
         '16x16': string
@@ -244,6 +245,7 @@ const newEmptyUser = () => {
             "48x48": '',
         },
         displayName: '',
+        accountId: '',
         self: '',
     } as IJiraUser
 }

--- a/src/rendering/countFenceRenderer.ts
+++ b/src/rendering/countFenceRenderer.ts
@@ -11,7 +11,8 @@ function renderSearchCount(el: HTMLElement, searchResults: IJiraSearchResults, s
     if (searchView.label !== '') {
         createSpan({ cls: `ji-tag is-link ${RC.getTheme()}`, text: searchView.label || `Count`, title: searchView.query, parent: tagsRow })
     }
-    createSpan({ cls: `ji-tag ${RC.getTheme()}`, text: searchResults.total.toString(), title: searchView.query, parent: tagsRow })
+    const total = searchResults.total || 0
+    createSpan({ cls: `ji-tag ${RC.getTheme()}`, text: total.toString(), title: searchView.query, parent: tagsRow })
     el.replaceChildren(RC.renderContainer([tagsRow]))
 }
 

--- a/src/rendering/searchFenceRenderer.ts
+++ b/src/rendering/searchFenceRenderer.ts
@@ -82,7 +82,9 @@ function getAccountBandStyle(account: IJiraIssueAccountSettings): string {
 
 function renderSearchFooter(rootEl: HTMLElement, searchView: SearchView, searchResults: IJiraSearchResults): HTMLElement {
     const searchFooter = createDiv({ cls: 'search-footer' })
-    const searchCount = `Total results: ${searchResults.total.toString()} - ${searchResults.account.alias}`
+    const total = searchResults.total || 0
+    const alias = searchResults.account?.alias || 'Unknown'
+    const searchCount = `Total results: ${total.toString()} - ${alias}`
 
     if(SettingsData.showJiraLink) {
         createEl('a', {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,7 +13,7 @@ const AUTHENTICATION_TYPE_DESCRIPTION = {
 
 export const DEFAULT_SETTINGS: IJiraIssueSettings = {
     accounts: [],
-    apiBasePath: '/rest/api/latest',
+    apiBasePath: '/rest/api/3',
     cacheTime: '15m',
     searchResultsLimit: 10,
     cache: {


### PR DESCRIPTION
Updated to use V3 Jira Search API endpoint and format. 

This likely will break if using old legacy self hosted or server versions of Jira.  Making PR for anybody else that lost the ability to use it on Jira Cloud. 