### PR TITLE
Add an optional "Web Base URL" to build the browser links rendered in notes

### DIFF
--- a/src/interfaces/settingsInterfaces.ts
+++ b/src/interfaces/settingsInterfaces.ts
@@ -50,6 +50,7 @@ export interface IJiraIssueSettings {
 export interface IJiraIssueAccountSettings {
     alias: string
     host: string
+    webBaseUrl: string
     authenticationType: EAuthenticationTypes
     username?: string
     password?: string

--- a/src/rendering/renderingCommon.ts
+++ b/src/rendering/renderingCommon.ts
@@ -26,16 +26,20 @@ export const JIRA_STATUS_COLOR_MAP_BY_NAME: Record<string, string> = {
     'Closed': 'is-success'
 }
 
+function resolveWebBaseUrl(account: IJiraIssueAccountSettings): string {
+    return (account.webBaseUrl || account.host).replace(/\/+$/, '')
+}
+
 export default {
     issueUrl(account: IJiraIssueAccountSettings, issueKey: string): string {
         try {
-            return (new URL(`${account.host}/browse/${issueKey}`)).toString()
+            return (new URL(`${resolveWebBaseUrl(account)}/browse/${issueKey}`)).toString()
         } catch (e) { return '' }
     },
 
     searchUrl(account: IJiraIssueAccountSettings, searchQuery: string): string {
         try {
-            return (new URL(`${account.host}/issues/?jql=${searchQuery}`)).toString()
+            return (new URL(`${resolveWebBaseUrl(account)}/issues/?jql=${searchQuery}`)).toString()
         } catch (e) { return '' }
     },
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,6 +42,7 @@ export const DEFAULT_SETTINGS: IJiraIssueSettings = {
 export const DEFAULT_ACCOUNT: IJiraIssueAccountSettings = {
     alias: 'Default',
     host: 'https://mycompany.atlassian.net',
+    webBaseUrl: '',
     authenticationType: EAuthenticationTypes.OPEN,
     password: '',
     priority: 1,
@@ -89,6 +90,7 @@ export class JiraIssueSettingTab extends PluginSettingTab {
                     {
                         priority: 1,
                         host: SettingsData.host,
+                        webBaseUrl: DEFAULT_ACCOUNT.webBaseUrl,
                         authenticationType: SettingsData.authenticationType,
                         username: SettingsData.username,
                         password: SettingsData.password,
@@ -250,6 +252,15 @@ export class JiraIssueSettingTab extends PluginSettingTab {
                 .setValue(newAccount.host)
                 .onChange(async value => {
                     newAccount.host = value
+                }))
+        new Setting(containerEl)
+            .setName('Web Base URL')
+            .setDesc('Optional base URL used for links rendered in notes (e.g. https://jira.mycompany.com). Empty means fall back to Host.')
+            .addText(text => text
+                .setPlaceholder('Example: https://jira.mycompany.com')
+                .setValue(newAccount.webBaseUrl)
+                .onChange(async value => {
+                    newAccount.webBaseUrl = value
                 }))
         new Setting(containerEl)
             .setName('Authentication type')

--- a/test/renderingCommon.test.ts
+++ b/test/renderingCommon.test.ts
@@ -7,6 +7,7 @@ import { SettingsData } from '../src/settings'
 import RC from '../src/rendering/renderingCommon'
 import { EColorSchema } from '../src/interfaces/settingsInterfaces'
 import * as main from '../src/main'
+import { TestAccountOpen } from './testData'
 
 const kLightCSSClass = 'is-light'
 const kDarkCSSClass = 'is-dark'
@@ -37,6 +38,21 @@ describe('RenderingCommon', () => {
             getConfigMock.mockReturnValueOnce('obsidian')
             SettingsData.colorSchema = EColorSchema.FOLLOW_OBSIDIAN
             expect(RC.getTheme()).toEqual(kDarkCSSClass)
+        })
+    })
+
+    describe('web links', () => {
+        test('uses webBaseUrl and strips trailing slashes', () => {
+            const account = { ...TestAccountOpen, webBaseUrl: 'https://jira.mycompany.com///' }
+
+            expect(RC.issueUrl(account, 'AAA-123')).toBe('https://jira.mycompany.com/browse/AAA-123')
+            expect(RC.searchUrl(account, 'project = TEST')).toBe('https://jira.mycompany.com/issues/?jql=project%20=%20TEST')
+        })
+
+        test('falls back to host when webBaseUrl is empty', () => {
+            const account = { ...TestAccountOpen, webBaseUrl: '', host: 'https://jira.mycompany.com///' }
+
+            expect(RC.issueUrl(account, 'AAA-123')).toBe('https://jira.mycompany.com/browse/AAA-123')
         })
     })
 

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -16,6 +16,7 @@ const StoredSettings = {
         password: 'passwordVal',
         color: 'colorVal',
         host: 'hostVal',
+        webBaseUrl: '',
         bareToken: 'bareToken',
         use2025Api: false,
     }],

--- a/test/testData.ts
+++ b/test/testData.ts
@@ -15,6 +15,7 @@ const kEmptyAccountCache = {
 export const TestAccountOpen = {
     alias: 'alias1',
     host: 'https://test-company.atlassian.net',
+    webBaseUrl: '',
     authenticationType: EAuthenticationTypes.OPEN,
     priority: 1,
     color: '#123456',
@@ -25,6 +26,7 @@ export const TestAccountOpen = {
 export const TestAccountBasic = {
     alias: 'alias2',
     host: 'host2',
+    webBaseUrl: '',
     authenticationType: EAuthenticationTypes.BASIC,
     username: 'username2',
     password: 'password2',


### PR DESCRIPTION
**Problem**
For Jira Cloud, the API can be accessed through https://api.atlassian.com/ex/jira/<cloud_id>. This works fine for fetching data, but the plugin also derives all user-facing links from the same host value. The result is links like:
`https://api.atlassian.com/ex/jira/<cloud_id>/browse/XYZ-123`
which are not browsable and return an error when clicked from a note. There is currently no way to decouple the API endpoint from the web UI address, so anyone using the api.atlassian.com gateway (or any setup where the API host differs from the public web address, e.g. a reverse proxy or internal API hostname) ends up with broken links.

https://github.com/marc0l92/obsidian-jira-issue/issues/186#issuecomment-4702024528

**Solution**
Introduce an optional webBaseUrl field on the account:
- Interface/defaults: new webBaseUrl: string property on the account object, defaulting to "". Existing accounts are merged against the defaults on load, so no migration is needed and behavior is unchanged for everyone who leaves it empty.
- Settings UI: a new "Web Base URL" text field in the account edit view, placed directly under "Host", with a description explaining that it is optional and only affects the links rendered in notes.
- Rendering: a small helper resolves the base URL as webBaseUrl || host (trimming trailing slashes). issueUrl() and searchUrl() in renderingCommon now use this helper, so the inline JIRA:XYZ-123 tags, the key column links in jira-search tables and the search result footer link all point to the browsable address.

**Behavior**
- Empty webBaseUrl → identical to today (host is used), fully backwards compatible.
- webBaseUrl = https://mycompany.atlassian.net → rendered links become https://mycompany.atlassian.net/browse/XYZ-123, while API requests keep using host.

**Scope / notes**
The change deliberately only affects outgoing links. API request building (buildUrl) is untouched. The "issue URL to tag" detection still matches against host; matching webBaseUrl as well could be a sensible follow-up, but is left out to keep this change minimal and focused.